### PR TITLE
perf(topo-editor): remove performance detrimental styles

### DIFF
--- a/components/TopoEditor/CanvasArea.tsx
+++ b/components/TopoEditor/CanvasArea.tsx
@@ -62,12 +62,10 @@ const style = {
   sketch: function(ctx: CanvasRenderingContext2D) {
     ctx.strokeStyle = "#60a5fa";
     ctx.lineWidth = 3;
-    ctx.setLineDash([15, 15]);
   },
   ghost: function(ctx: CanvasRenderingContext2D) {
     ctx.strokeStyle = "rgba(0, 0, 0, 0.2)";
     ctx.lineWidth = 6;
-    ctx.shadowColor = "rgba(0, 0, 0, 0)";
   },
   geometry: {
     spline: {
@@ -242,7 +240,6 @@ export default function CanvasArea() {
 
     // "draw paper"
     ctx.save();
-    ctx.shadowColor = "rgba(0, 0, 0, 0.4)";
     ctx.fillStyle = "#fff";
     ctx.fillRect(0, 0, world.size.width, world.size.height);
     ctx.restore();


### PR DESCRIPTION
Not sure why, but when zooming in on the dashed line, the performance takes a huge hit. Also, remove the shadow colors that were missed in f7ab830d1ba2ca469e952e6c597af146c16bce7a